### PR TITLE
fixed bug whith empty datasets

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -684,8 +684,11 @@ func (cn *conn) simpleQuery(q string) (res *rows, err error) {
 			// Set the result and tag to the last command complete if there wasn't a
 			// query already run. Although queries usually return from here and cede
 			// control to Next, a query with zero results does not.
-			if t == 'C' && res.colNames == nil {
+			if t == 'C' {
 				res.result, res.tag = cn.parseComplete(r.string())
+				if res.colNames != nil {
+					return
+				}
 			}
 			res.done = true
 		case 'Z':


### PR DESCRIPTION
if we have 4 datasets and one of them is empty, driver thinks that we have only 3 datasets and skip the empty one